### PR TITLE
[GS's ActivityPub plugin] Moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A little help for implementing ActivityPub.
 Connecting the ActivityPub federation with another federation.
 
 * [Bridgy Fed](https://github.com/snarfed/bridgy-fed) - A bridge between IndieWeb and ActivityPub, OStatus.
-* [GNU Social ActivityPub Plugin](https://git.gnu.io/dansup/ActivityPub) - Plugin for GNU Social to add ActivityPub support.
+* [GNU social ActivityPub Plugin](https://notabug.org/diogo/gnu-social/src/nightly/plugins/ActivityPub) - Plugin for GNU social to add ActivityPub support.
 * [Osada](https://macgirvin.com/wiki/mike/Osada/Home) - A bridge between Zot protocol and ActivityPub, OStatus, Diaspora etc.
 * [RSS to ActivityPub](https://github.com/dariusk/rss-to-activitypub) - An RSS to ActivityPub converter. 
 


### PR DESCRIPTION
- Updated GNU social's ActivityPub plugin's repository address
- s/GNU Social/GNU social