### PR TITLE
correct forge-fed information and category

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@
 [ActivityPub](https://www.w3.org/TR/activitypub/) is W3C standard, decentralized social networking protocol.
 
 ## Contents
-* [Official](#official)
+* [Specifications](#specifications)
 * [Services](#services)
 * [Implementations](#implementations)
 * [Libraries](#libraries)
 * [Bridges](#bridges)
 
-## Official
-The official information.
+## Specifications
+Information for developers and implementers.
 
 * [ActivityPub Website](https://activitypub.rocks/) - The official website of ActivityPub protocol.
 * [W3C ActivityPub Standard](https://www.w3.org/TR/activitypub/) - The standard document of ActivityPub.
+* [ForgeFed](https://forgefed.peers.community/) - Federation protocol for interoperable project management and source code hosting services (aka: forges).
 
 ## Services
 Services supporting ActivityPub federation.
 
 * [Dokieli](https://dokie.li/#introduction) - A clientside editor for decentralised article publishing, annotations and social interactions.
-* [ForgeFed](https://github.com/forgefed/forgefed) - An extension to ActivityPub for web-based Git services federation.
 * [Funkwhale](https://funkwhale.audio/) - A modern, self-hosted, free and open-source music server.
 * [Hubzilla](https://project.hubzilla.org) - Macroblogging social network supports Zot, OStatus, diaspora, ActivityPub.
 * [Mastodon](https://joinmastodon.org/) - Microblogging service based on ActivityPub and OStatus protocol.


### PR DESCRIPTION
the current information for forge-fed is incorrect in multiple ways

1. the github repo was used only for a brief period in 2018, while forming a work-group for exploratory discussions - those interested in current and future development, should refer to the forge-fed website

2. forge-fed is not specific to git - it is intentionally VCS-agnostic, so that it is applicable to any forge, regardless of which VCS each supports

3. forge-fed is not a service nor any sort of implementation - it is a work-group and a specification for implementers, placing it in the same category as activity-pub itself - for that reason, i propose the change of the "Official" category to the more general: "Specifications", or perhaps "Work-groups and Specifications", allowing for more projects of that class in the future