### PR TITLE
remove PeerPX

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Services supporting ActivityPub federation.
 * [Hubzilla](https://project.hubzilla.org) - Macroblogging social network supports Zot, OStatus, diaspora, ActivityPub.
 * [Mastodon](https://joinmastodon.org/) - Microblogging service based on ActivityPub and OStatus protocol.
 * [Misskey](https://github.com/syuilo/misskey) - Microblogging service based on ActivityPub.
-* [PeerPx](https://github.com/peerpx/peerpx) - A federated alternative to 500px or Flickr.
 * [PeerTube](https://github.com/Chocobozzz/PeerTube) - Video streaming platform with ActivityPub and WebTorrent.
 * [PixelFed](https://pixelfed.org/) - Federated Image Sharing.
 * [Pleroma](https://pleroma.social/) - Lightweight microblogging service based on ActivityPub and OStatus protocol.


### PR DESCRIPTION
This project was abandoned 4 years ago and dilutes the active awesome projects.