### PR TITLE
Remove reel2bits (project abandoned)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Services supporting ActivityPub federation.
 * [ActivityPub for WordPress](https://wordpress.org/plugins/activitypub/) - An ActivityPub plugin for WordPress.
 * [ActivityPub for Drupal](https://www.drupal.org/project/activitypub) - An ActivityPub module for the Drupal open-source digital experience platform.
 * [Mobilizon](https://joinmobilizon.org/en/) - A federated organization and mobilization platform.
-* [reel2bits](https://reel2bits.org/) - A Federated audio and podcasts sharing platform.
 * [Socialhome](https://socialhome.network/) - A federated personal profile with social networking functionality. 
 * [Lemmy](https://github.com/dessalines/lemmy) - Building a federated alternative to reddit in rust.
 * [lotide](https://sr.ht/~vpzom/lotide/) - Federated forum / link aggregator using ActivityPub.


### PR DESCRIPTION
According to the reel2bits page the project is no longer active, so removing from this list.